### PR TITLE
Clean up menu design

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -2,33 +2,65 @@
   <div id="wrapper" @click="onClickOutside">
     <div id="hypothesis" v-if="visible">
       <div id="form">
-        <label for="token">API token:</label>
-        <input id="token" :value="apiToken" @change="setAPIToken" />
-        <button id="fetch" @click="fetchUpdates()">Fetch Updates</button>
-        <label for="user">User:</label>
-        <input
-          id="user"
-          placeholder="username@hypothes.is"
-          :value="user"
-          @change="setUser"
-        />
-        <button id="create" @click="loadPage(item)">Get Selected Page</button>
-        <v-select
-          ref="select"
-          class="select"
-          id="uri"
-          v-model="item"
-          :get-option-label="(i) => `${i.title} | ${i.uri}`"
-          :filter="fuseSearch"
-          :options="items"
-          :clearable="false"
+        <fieldset id="accountSetupFields">
+          <legend>Account setup</legend>
+          <div class="fieldLabel">
+            <label for="token">API token</label>
+          </div>
+          <input
+            id="token"
+            :value="apiToken"
+            @change="setAPIToken"
+            spellcheck="false"
+          />
+          <div class="fieldLabel">
+            <label for="user">Username</label>
+          </div>
+          <input
+            id="user"
+            placeholder="username@hypothes.is"
+            :value="user"
+            @change="setUser"
+          />
+          <p class="text-small">
+            If you are not using a third party hypothes.is provider, your user
+            account is <code>username@hypothes.is</code>
+          </p>
+        </fieldset>
+        <button
+          id="fetch"
+          @click="fetchUpdates()"
+          :disabled="fetching || updating"
         >
-          <template #option="{ uri, title }">
-            <b>{{ title }}</b>
-            <br />
-            {{ uri }}
-          </template>
-        </v-select>
+          <span v-if="fetching || updating">Fetching updates... </span
+          ><span v-else>🔄 Fetch latest notes</span>
+        </button>
+        <fieldset>
+          <legend>Create page from hypothesis notes</legend>
+          <v-select
+            ref="select"
+            class="select"
+            id="uri"
+            v-model="item"
+            :get-option-label="(i) => `${i.title} | ${i.uri}`"
+            :filter="fuseSearch"
+            :options="items"
+            :clearable="false"
+          >
+            <template #option="{ uri, title }">
+              <b>{{ title }}</b>
+              <br />
+              {{ uri }}
+            </template>
+          </v-select>
+          <button
+            id="create"
+            @click="loadPage(item)"
+            :disabled="item.uri === '' && item.title === ''"
+          >
+            Add page notes to graph
+          </button>
+        </fieldset>
       </div>
     </div>
     <div v-if="fetching || updating" class="lds-ripple">
@@ -231,7 +263,8 @@ export default {
         const logseqTitle =
           (await this.findPageName(uri)) || (await this.findPageNameV1(uri));
 
-        //If page isn't found, create new one with hypothesisTitle. This approach allows for the title to be changed by the user
+        //If page isn't found, create new one with hypothesisTitle. This
+        //approach allows for the title to be changed by the user
         const pageTitle = logseqTitle
           ? logseqTitle
           : "hypothesis__/" + hypothesisTitle;

--- a/src/App.vue
+++ b/src/App.vue
@@ -109,7 +109,7 @@ export default {
       ].reverse();
     },
   },
-  mounted() {
+  async mounted() {
     logseq.once("ui:visible:changed", ({ visible }) => {
       visible && (this.visible = true);
       // init
@@ -126,7 +126,7 @@ export default {
       this.theme = s.mode;
     });
 
-    this.theme = getTheme();
+    this.theme = (await logseq.App.getUserConfig()).preferredThemeMode;
   },
   methods: {
     fuseSearch(options, search) {
@@ -136,12 +136,6 @@ export default {
       return search.length
         ? fuse.search(search).map(({ item }) => item)
         : fuse.list;
-    },
-    getTheme() {
-      return top?.document.querySelector("html")?.getAttribute("data-theme") ??
-        matchMedia("prefers-color-scheme: dark").matches
-        ? "dark"
-        : "light";
     },
     hideMainUI() {
       logseq.hideMainUI();

--- a/src/App.vue
+++ b/src/App.vue
@@ -336,7 +336,7 @@ export default {
       if (!pagePropBlock) {
         pagePropBlock = await logseq.Editor.insertBlock(
           page.name,
-          "Hypothesis metadata",
+          pagePropBlock,
           {
             isPageBlock: true,
             properties: {

--- a/src/App.vue
+++ b/src/App.vue
@@ -209,13 +209,12 @@ export default {
             const exact = target[0]?.selector?.filter((s) => "exact" in s)[0]
               ?.exact;
             tags = tags.map((t) => `#[[${t}]]`).join(" ");
-            let highlight = "";
-            let notes = "";
+            let content = "";
             if (exact) {
-              highlight += `> ${exact} ${tags}\n`;
-              if (text) notes = text;
+              content += `📌 ${exact} ${tags}`;
+              if (text) content += `\n📝 ${text}`;
             } else {
-              highlight += `${text} ${tags}\n`;
+              content += `📝 ${text} ${tags}`;
             }
             let properties = { hid: id, updated };
             // add deleted references
@@ -224,7 +223,7 @@ export default {
                 acc.push([
                   r,
                   {
-                    highlight: "🗑️",
+                    content: "🗑️",
                     properties: { hid: r },
                     parent: references[i - 1],
                   },
@@ -235,8 +234,7 @@ export default {
             acc.push([
               id,
               {
-                highlight,
-                notes,
+                content,
                 properties,
                 parent: references
                   ? references[references.length - 1]
@@ -354,8 +352,8 @@ export default {
 
       for (const n of n_b) {
         const { hid, updated } = n.properties;
-        const content = n.highlight.trim();
-        const { parent, after, notes } = n;
+        const content = n.content.trim();
+        const { parent, after } = n;
         const source = blockMap.get(parent ?? after);
         const block = await logseq.Editor.insertBlock(
           source?.uuid ?? page.name,
@@ -369,11 +367,6 @@ export default {
             isPageBlock: !source,
           }
         );
-        if (notes) {
-          await logseq.Editor.insertBlock(block.uuid, notes, {
-            sibling: false,
-          });
-        }
         blockMap.set(hid, block);
       }
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -2,8 +2,8 @@
   <div id="wrapper" @click="onClickOutside">
     <div id="hypothesis" v-if="visible" :class="theme">
       <div id="form">
-        <fieldset id="accountSetupFields">
-          <legend>Account setup</legend>
+        <div class="accountSetupFields">
+          <h2>Account setup</h2>
           <div class="fieldLabel">
             <label for="token">API token</label>
           </div>
@@ -26,7 +26,7 @@
             If you are not using a third party hypothes.is provider, your user
             account is <code>username@hypothes.is</code>
           </p>
-        </fieldset>
+        </div>
         <button
           id="fetch"
           @click="fetchUpdates()"
@@ -35,32 +35,30 @@
           <span v-if="fetching || updating">Fetching updates... </span
           ><span v-else>🔄 Fetch latest notes</span>
         </button>
-        <fieldset>
-          <legend>Create page from hypothesis notes</legend>
-          <v-select
-            ref="select"
-            class="select"
-            id="uri"
-            v-model="item"
-            :get-option-label="(i) => `${i.title} | ${i.uri}`"
-            :filter="fuseSearch"
-            :options="items"
-            :clearable="false"
-          >
-            <template #option="{ uri, title }">
-              <b>{{ title }}</b>
-              <br />
-              {{ uri }}
-            </template>
-          </v-select>
-          <button
-            id="create"
-            @click="loadPage(item)"
-            :disabled="item.uri === '' && item.title === ''"
-          >
-            Add page notes to graph
-          </button>
-        </fieldset>
+        <h2>Create page from hypothesis notes</h2>
+        <v-select
+          ref="select"
+          class="select"
+          id="uri"
+          v-model="item"
+          :get-option-label="(i) => `${i.title} | ${i.uri}`"
+          :filter="fuseSearch"
+          :options="items"
+          :clearable="false"
+        >
+          <template #option="{ uri, title }">
+            <b>{{ title }}</b>
+            <br />
+            {{ uri }}
+          </template>
+        </v-select>
+        <button
+          id="create"
+          @click="loadPage(item)"
+          :disabled="item.uri === '' && item.title === ''"
+        >
+          Add page notes to graph
+        </button>
       </div>
     </div>
     <div v-if="fetching || updating" class="lds-ripple">

--- a/src/App.vue
+++ b/src/App.vue
@@ -124,7 +124,7 @@ export default {
       this.theme = s.mode;
     });
 
-    this.theme = (await logseq.App.getUserConfig()).preferredThemeMode;
+    this.theme = (await logseq.App.getUserConfigs()).preferredThemeMode;
   },
   methods: {
     fuseSearch(options, search) {
@@ -304,7 +304,7 @@ export default {
       if (finds.length > 1) {
         //TODO: throw error
         throw new Error("Multiple pages has the same title");
-      } else if (finds == 0) {
+      } else if (finds.length == 0) {
         //throw new Error("Page doesn't exist")
         console.log("Page doesn't exist");
         return;

--- a/src/index.css
+++ b/src/index.css
@@ -15,11 +15,6 @@ body {
   bottom: 0;
 }
 
-html[data-theme="light"] {
-  --ls-bg-color: rgb(255, 255, 255);
-  --ls-color-primary: rgb(107, 114, 128);
-}
-
 p {
   color: var(--ls-color-primary);
   margin: 0;
@@ -30,6 +25,8 @@ p {
 }
 
 #hypothesis {
+  --ls-bg-color: rgb(0, 0, 0);
+  --ls-color-primary: rgb(255, 255, 255);
   max-width: fit-content;
   border-radius: 0.25rem;
   position: absolute;
@@ -47,6 +44,11 @@ p {
     var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 
+#hypothesis.light {
+  --ls-bg-color: rgb(255, 255, 255);
+  --ls-color-primary: rgb(107, 114, 128);
+}
+
 #form {
   display: flex;
   flex-direction: column;
@@ -56,18 +58,39 @@ p {
   min-width: 350px;
 }
 
+.light .select .vs__search::placeholder,
+.light .select .vs__dropdown-toggle,
+.light .select .vs__dropdown-menu {
+  background: white;
+  color: black;
+}
+
 .select .vs__search::placeholder,
 .select .vs__dropdown-toggle,
 .select .vs__dropdown-menu {
-  background: white;
-  color: black;
+  background: #333;
+  color: white;
   font-size: 85%;
 }
+
+.light .vs__dropdown-option {
+  color: black;
+}
+
+.dark .vs__dropdown-option {
+  color: white;
+}
+
 .vs__selected-options {
   width: 0;
 }
-.vs__selected {
+
+.light .vs__selected {
   color: black;
+}
+
+.vs__selected {
+  color: white;
   display: block;
   white-space: nowrap;
   text-overflow: ellipsis;
@@ -75,9 +98,34 @@ p {
   overflow: hidden;
 }
 
-#fetch {
-  min-height: 3rem;
-  padding: 0.5rem 1rem;
+.vs__clear {
+  fill: #0084c7;
+}
+
+.dark .vs--single.vs--open .vs__selected {
+  opacity: 0.8;
+}
+
+#fetch,
+button {
+  background-color: #0084c7;
+  border-radius: 8px;
+  border: 0;
+  color: white;
+  min-height: 2rem;
+  padding: 0.25rem 0.5rem;
+  width: fit-content;
+}
+
+#fetch:hover:not(:disabled),
+button:hover:not(:disabled) {
+  background-color: rgb(0, 91, 138);
+}
+
+#fetch:disabled,
+button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 
 #create {
@@ -133,6 +181,13 @@ input {
 
 #accountSetupFields input {
   margin-bottom: 0.5rem;
+}
+
+.dark #accountSetupFields input {
+  color: white;
+  background-color: #333;
+  border: 2px solid #333;
+  border-style: inset;
 }
 
 #accountSetupFields p {

--- a/src/index.css
+++ b/src/index.css
@@ -14,22 +14,46 @@ body {
   right: 0;
   bottom: 0;
 }
+
+html[data-theme="light"] {
+  --ls-bg-color: rgb(255, 255, 255);
+  --ls-color-primary: rgb(107, 114, 128);
+}
+
+p {
+  color: var(--ls-color-primary);
+  margin: 0;
+}
+
+.text-small {
+  font-size: 0.8rem;
+}
+
 #hypothesis {
-  max-width: 100%;
+  max-width: fit-content;
+  border-radius: 0.25rem;
   position: absolute;
-  top: 3em;
-  right: 0;
-  background-color: #ccc;
+  top: 3rem;
+  right: 2rem;
+  background-color: var(--ls-bg-color);
+  color: var(--ls-color-primary);
+  padding: 0.5rem 1rem;
+  --tw-shadow: 0 4px 6px -1px rgb(0 0 0/0.1), 0 2px 4px -2px rgb(0 0 0/0.1);
+  --tw-shadow-colored: 0 4px 6px -1px var(--tw-shadow-color),
+    0 2px 4px -2px var(--tw-shadow-color);
+  -webkit-box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000),
+    var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000),
+    var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 
 #form {
-  display: grid;
-  grid-template-areas:
-    "label input fetch"
-    "label input create"
-    "select select select";
-  grid-gap: 0.1em 1em;
-  padding: 0.1em;
+  display: flex;
+  flex-direction: column;
+  padding: 0.25em;
+  gap: 1rem;
+  max-width: fit-content;
+  min-width: 350px;
 }
 
 .select .vs__search::placeholder,
@@ -51,17 +75,19 @@ body {
   overflow: hidden;
 }
 
-.select {
-  grid-area: select;
-}
 #fetch {
-  grid-area: fetch;
+  min-height: 3rem;
+  padding: 0.5rem 1rem;
 }
+
 #create {
-  grid-area: create;
+  margin-top: 1rem;
+  min-height: 2rem;
+  padding: 0.5rem 1rem;
 }
+
 input {
-  width: 30em;
+  padding: 0.5rem;
 }
 
 #hypothesis iframe {
@@ -85,6 +111,35 @@ input {
 .lds-ripple div:nth-child(2) {
   animation-delay: -0.5s;
 }
+
+/* Fields */
+
+.fieldLabel {
+  margin-bottom: 0.5rem;
+}
+
+#token {
+  max-width: 40ch;
+}
+
+#user {
+  max-width: 30ch;
+}
+
+#accountSetupFields {
+  display: flex;
+  flex-direction: column;
+}
+
+#accountSetupFields input {
+  margin-bottom: 0.5rem;
+}
+
+#accountSetupFields p {
+  margin-bottom: 0.25rem;
+}
+
+/* Animations */
 @keyframes lds-ripple {
   0% {
     top: 36px;
@@ -93,6 +148,7 @@ input {
     height: 0;
     opacity: 1;
   }
+
   100% {
     top: 0px;
     left: 0px;

--- a/src/index.css
+++ b/src/index.css
@@ -188,11 +188,12 @@ input {
 }
 
 .dark .accountSetupFields input {
-  color: white;
   background-color: #333;
   border: 2px solid #333;
   border-style: inset;
 }
+
+.dark input { color: white }
 
 .accountSetupFields p {
   margin-bottom: 0.25rem;

--- a/src/index.css
+++ b/src/index.css
@@ -34,7 +34,7 @@ p {
   right: 2rem;
   background-color: var(--ls-bg-color);
   color: var(--ls-color-primary);
-  padding: 0.5rem 1rem;
+  padding: 1rem;
   --tw-shadow: 0 4px 6px -1px rgb(0 0 0/0.1), 0 2px 4px -2px rgb(0 0 0/0.1);
   --tw-shadow-colored: 0 4px 6px -1px var(--tw-shadow-color),
     0 2px 4px -2px var(--tw-shadow-color);
@@ -54,7 +54,6 @@ p {
   flex-direction: column;
   padding: 0.25em;
   gap: 1rem;
-  max-width: fit-content;
   min-width: 350px;
 }
 
@@ -108,6 +107,7 @@ p {
 
 #fetch,
 button {
+  align-self: flex-end;
   background-color: #0084c7;
   border-radius: 8px;
   border: 0;
@@ -167,31 +167,36 @@ input {
 }
 
 #token {
-  max-width: 40ch;
+  max-width: 55ch;
 }
 
 #user {
   max-width: 30ch;
 }
 
-#accountSetupFields {
+.accountSetupFields {
   display: flex;
   flex-direction: column;
 }
 
-#accountSetupFields input {
+.accountSetupFields h2 {
+  margin-top: 0
+}
+
+.accountSetupFields input {
   margin-bottom: 0.5rem;
 }
 
-.dark #accountSetupFields input {
+.dark .accountSetupFields input {
   color: white;
   background-color: #333;
   border: 2px solid #333;
   border-style: inset;
 }
 
-#accountSetupFields p {
+.accountSetupFields p {
   margin-bottom: 0.25rem;
+  /* max-width: 72ch; */
 }
 
 /* Animations */


### PR DESCRIPTION
Originally phildenhoff/logseq-hypothesis#1

Updates the menu design to be a little more user-friendly. At the same time, it adds (rudimentary) light/dark themeing support.

Unfortunately, some incantation I typed brought the vertical & horizontal scrollbars back. That wasn't my intention, but I also cannot, for the life of me, fix it. Maybe someone else can sort that out 😅

## Before

![Screen Shot 2022-05-05 at 9 53 53 AM](https://user-images.githubusercontent.com/17505728/166973709-7b351932-bd71-47b6-ae80-d0dacc157b41.png)

## After
### Light

![Screen Shot 2022-05-12 at 1 59 53 AM](https://user-images.githubusercontent.com/17505728/168040559-92948c23-7f2f-492c-aeaa-279c184002dc.png)


### Dark

![Screen Shot 2022-05-12 at 1 59 42 AM](https://user-images.githubusercontent.com/17505728/168040594-21bfb6f6-7258-44fe-a4cb-5c60448db7ca.png)

![Screen Shot 2022-05-12 at 1 59 47 AM](https://user-images.githubusercontent.com/17505728/168040600-b762510c-b06d-43ef-8aac-bb0260d2aaf2.png)
