### PR TITLE
added the option for the plugin to render hypothesis elements as links

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -320,6 +320,8 @@ export default {
       return finds.length ? finds[0]["original-name"] : null;
     },
     async loadPageNotes(page, uri, title, noteMap) {
+      const { itemsAsLinks } =
+        logseq.settings;
       if (!page || !uri) return;
 
       const pageProperties = {
@@ -352,9 +354,15 @@ export default {
 
       for (const n of n_b) {
         const { hid, updated } = n.properties;
-        const content = n.content.trim();
+        let content = n.content.trim();
         const { parent, after } = n;
         const source = blockMap.get(parent ?? after);
+
+        if (itemsAsLinks){
+            //then we want the content to be wrapped in a link that references the annotation on the url that the item originiated from
+            content = `<a href="${uri + "#annotations:" + hid}">${content}</a>`;
+        }
+
         const block = await logseq.Editor.insertBlock(
           source?.uuid ?? page.name,
           content,

--- a/src/settingsSchema.json
+++ b/src/settingsSchema.json
@@ -36,5 +36,11 @@
     "key": "deletedFormat",
     "title": "Deleted Content Format",
     "type": "string"
+  },
+  {
+    "default": false,
+    "key": "itemsAsLinks",
+    "title": "Make the notes, highlights and annotations links to the hypothes.is page",
+    "type": "boolean"
   }
 ]


### PR DESCRIPTION
basically this code just implements an option that allows the hypothesis items that get rendered to be clickable links that take you directly to the source item

this allows us to do things like what is possible with the logseq pdf annotations, where the highlights are clickable and take you directly to the line in the PDF